### PR TITLE
fix: Replace non-existent _extract_components method with existing pa…

### DIFF
--- a/radiology-cleaner-app/backend/nhs_lookup_engine.py
+++ b/radiology-cleaner-app/backend/nhs_lookup_engine.py
@@ -601,7 +601,7 @@ class NHSLookupEngine:
             # CRITICAL SAFETY FIX: Check for explicit contrast mismatch
             # Calculate contrast score to detect dangerous explicit contradictions
             input_contrast = extracted_input_components.get('contrast', [])
-            nhs_components = self._extract_components(entry.get('primary_source_name', ''))
+            nhs_components = entry.get('_parsed_components', {})
             nhs_contrast = nhs_components.get('contrast', [])
             contrast_mismatch_score = self.config.get('contrast_mismatch_score', 0.05)
             


### PR DESCRIPTION
…rsed components

The contrast mismatch detection code was calling self._extract_components() which doesn't exist, causing AttributeError. Fixed by using the pre-parsed components that are already stored in entry['_parsed_components'] during initialization.

🤖 Generated with [Claude Code](https://claude.ai/code)