### PR TITLE
feat: Suppress third-party library debug noise in logs

### DIFF
--- a/radiology-cleaner-app/backend/app.py
+++ b/radiology-cleaner-app/backend/app.py
@@ -45,6 +45,23 @@ except ImportError as e:
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
+# Reduce third-party library debug noise
+logging.getLogger('botocore').setLevel(logging.CRITICAL)
+logging.getLogger('botocore.hooks').setLevel(logging.CRITICAL)
+logging.getLogger('botocore.loaders').setLevel(logging.CRITICAL)
+logging.getLogger('botocore.client').setLevel(logging.CRITICAL)
+logging.getLogger('botocore.endpoint').setLevel(logging.CRITICAL)
+logging.getLogger('botocore.regions').setLevel(logging.CRITICAL)
+logging.getLogger('botocore.utils').setLevel(logging.CRITICAL)
+logging.getLogger('boto3').setLevel(logging.CRITICAL)
+logging.getLogger('urllib3').setLevel(logging.WARNING)
+logging.getLogger('urllib3.connectionpool').setLevel(logging.WARNING)
+logging.getLogger('charset_normalizer').setLevel(logging.WARNING)
+logging.getLogger('faiss').setLevel(logging.WARNING)
+# Complete silence for AWS/HTTP libraries
+logging.getLogger('requests').setLevel(logging.WARNING)
+logging.getLogger('requests.packages.urllib3').setLevel(logging.WARNING)
+
 app = Flask(__name__)
 CORS(app, 
      origins=[

--- a/radiology-cleaner-app/backend/secondary_pipeline.py
+++ b/radiology-cleaner-app/backend/secondary_pipeline.py
@@ -19,7 +19,7 @@ import yaml
 import threading
 
 # Configure logging
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Global cache for shared secondary pipeline instance


### PR DESCRIPTION
- Set botocore and all its sub-loggers to CRITICAL level
- Suppress urllib3, requests, charset_normalizer, and faiss debug messages
- Changed secondary_pipeline.py from DEBUG to INFO level
- Logs now focus on application-level messages only

🤖 Generated with [Claude Code](https://claude.ai/code)