### PR TITLE
feat: Add automatic validation cache refresh at processing start

### DIFF
--- a/radiology-cleaner-app/backend/app.py
+++ b/radiology-cleaner-app/backend/app.py
@@ -313,6 +313,24 @@ def _ensure_app_is_initialized():
             _initialize_app()
             _app_initialized = True
 
+def _refresh_validation_caches():
+    """
+    Refresh validation caches from R2 to ensure latest human-in-the-loop feedback is used.
+    Called at the start of every processing run to pick up new validation entries.
+    """
+    global nhs_lookup_engine
+    if nhs_lookup_engine:
+        try:
+            refresh_result = nhs_lookup_engine.reload_validation_caches()
+            if refresh_result.get('status') == 'success':
+                logger.info(f"[CACHE-REFRESH] Updated validation caches: approved={refresh_result.get('approved_count', 0)} (Δ{refresh_result.get('approved_delta', 0):+d}), rejected={refresh_result.get('rejected_count', 0)} (Δ{refresh_result.get('rejected_delta', 0):+d})")
+            else:
+                logger.warning(f"[CACHE-REFRESH] Validation cache refresh returned non-success status: {refresh_result}")
+        except Exception as e:
+            logger.error(f"[CACHE-REFRESH] Failed to refresh validation caches: {e}")
+    else:
+        logger.warning("[CACHE-REFRESH] NHS lookup engine not available for cache refresh")
+
 def process_exam_request(exam_name: str, modality_code: Optional[str], nlp_processor: NLPProcessor, debug: bool = False, reranker_key: Optional[str] = None, data_source: Optional[str] = None, exam_code: Optional[str] = None, run_secondary_inline: bool = True) -> Dict:
     """Central processing logic for a single exam."""
     if debug:
@@ -968,6 +986,7 @@ def _get_model_description(model_key: str) -> str:
 def parse_enhanced():
     """Enhanced parsing endpoint for single exam processing"""
     _ensure_app_is_initialized()
+    _refresh_validation_caches()  # Refresh validation caches for latest human feedback
     start_time = time.time()
     
     try:
@@ -1322,6 +1341,7 @@ def parse_batch():
         return '', 200
     
     _ensure_app_is_initialized()
+    _refresh_validation_caches()  # Refresh validation caches for latest human feedback
     start_time = time.time()
     
     try:
@@ -1520,6 +1540,7 @@ def random_sample():
     and passes them to the batch processing endpoint.
     """
     _ensure_app_is_initialized()
+    _refresh_validation_caches()  # Refresh validation caches for latest human feedback
     start_time = time.time()
     
     try:


### PR DESCRIPTION
- Add _refresh_validation_caches() function to refresh human-in-the-loop validation data
- Call cache refresh at start of all processing endpoints (parse_enhanced, parse_batch, random_sample)
- Ensures latest approved/rejected mappings are used for every processing run
- Provides detailed logging of cache updates with delta counts
- Maintains performance by refreshing once per processing run, not per individual exam

🤖 Generated with [Claude Code](https://claude.ai/code)